### PR TITLE
Add embedded follow-up form section

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,24 @@
       </form>
       <p class="access__error" id="accessError" role="alert" aria-live="polite"></p>
     </section>
+
+    <section class="form-embed" aria-labelledby="formEmbedTitle">
+      <div class="form-embed__header">
+        <h2 id="formEmbedTitle">Formulario de seguimiento</h2>
+        <p>Completa el formulario para compartir tus impresiones tras trabajar las actividades.</p>
+      </div>
+      <div class="form-embed__frame">
+        <iframe
+          src="https://forms.office.com/e/K44sPaw4NE?embed=true"
+          title="Formulario de seguimiento"
+          loading="lazy"
+          allowfullscreen
+          webkitallowfullscreen
+          mozallowfullscreen
+          msallowfullscreen>
+        </iframe>
+      </div>
+    </section>
   </main>
 
   <footer class="footer">

--- a/styles.css
+++ b/styles.css
@@ -65,6 +65,38 @@ section h3 {
   color: var(--primary-color);
 }
 
+.form-embed {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-embed__header {
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.form-embed__header p {
+  margin: 0;
+  color: #4a5568;
+}
+
+.form-embed__frame {
+  width: min(100%, 760px);
+  margin: 0 auto;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 15px 30px rgba(44, 82, 130, 0.12);
+}
+
+.form-embed__frame iframe {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border: 0;
+  background-color: white;
+}
+
 .access__form {
   display: grid;
   gap: 0.75rem;


### PR DESCRIPTION
## Summary
- add a dedicated section that embeds the seguimiento form after the access panel
- style the new section so the iframe stays centered, responsive, and consistent with the page aesthetic

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d54bb53e88832d8a1cbab0e2443ccc